### PR TITLE
feat: Kafka prodcuer sent different datas

### DIFF
--- a/Producer-Sending-Different-Data-Types.md
+++ b/Producer-Sending-Different-Data-Types.md
@@ -1,0 +1,139 @@
+### # Kafka Producer and Consumer with Different Data Types
+
+This guide explains how to use Apache Kafka to send and receive messages with different data types, including lists and
+collections, rather than just the default String key and String value.
+
+## Prerequisites
+
+- Apache Kafka installed and running
+- Java Development Kit (JDK) installed
+- Maven or Gradle for dependency management
+
+## Dependencies
+
+Make sure to include the following dependencies in your `pom.xml` (for Maven) or `build.gradle` (for Gradle):
+
+### Maven
+
+```xml
+
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>3.0.0</version> <!-- Use the latest version -->
+</dependency>
+<dependency>
+<groupId>com.fasterxml.jackson.core</groupId>
+<artifactId>jackson-databind</artifactId>
+<version>2.12.3</version> <!-- Use the latest version -->
+</dependency>
+```
+
+1. Using a Custom Serializer:
+    - **Send data with List**: Using List<Producer>, you need to create a custom serializer that knows how to convert a
+      `List<Product>` into a byte array.
+    - This serializer would typically convert the list to a JSON string `(or another format)` and then serialize that
+      string.
+
+### Example of Custom Serializer for List
+
+Sending `List<Product>` directly, you would need to implement a custom serializer. Here’s a simple example of what
+that might look like:
+
+```java
+import org.apache.kafka.common.serialization.Serializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+public class ListProducerSerializer implements Serializer<List<Producer>> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public byte[] serialize(String topic, List<Producer> data) {
+        try {
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new RuntimeException("Error serializing List<Producer>", e);
+        }
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // Configuration if needed
+    }
+
+    @Override
+    public void close() {
+        // Cleanup if needed
+    }
+}
+```
+
+### Update Producer Configuration
+
+update producer configuration to use this custom serializer:
+
+```java
+import java.util.Properties;
+
+public static Properties getKafkaProperties() {
+    Properties props = new Properties();
+    props.setProperty(BOOTSTRAP_SERVERS, HOSTNAME);
+    props.setProperty(ACKS, "all");
+    props.setProperty(RETRIES, Integer.toString(Integer.MAX_VALUE));
+    props.setProperty(PRODUCER_KEY_SERIALIZER, StringSerializer.class.getName());
+    props.setProperty(PRODUCER_VALUE_SERIALIZER, ListProducerSerializer.class.getName()); // Use your custom serializer
+    props.setProperty("linger.ms.config", "3");
+    props.setProperty("compression.type", "snappy");
+    props.setProperty("batch.size", Integer.toString(32 * 1024));
+    return props;
+}
+
+```
+
+### Sending the Message
+
+With the custom serializer in place, you can continue to send `List<Product>` as the value:
+
+```java
+public static void sendMessge() {
+    Properties props = ProducerConfig.getKafkaProperties();
+    for (int j = 0; j < 2; j++) {
+        for (int i = 0; i < 100; i++) {
+            String key = "truck_id" + i;
+            try (KafkaProducer<String, List<Product>> producers = new KafkaProducer<>(props)) {
+                ProducerRecord<String, List<Product>> record = new ProducerRecord<>(TOPIC, key, producers);
+                producer.send(record, (metadata, exception) -> {
+                    if (exception != null) {
+                        log.error("Error sending record", exception);
+                    } else {
+                        log.info("Sent message with key: {} | partition: {} |, offset: {} |, timestamp: {} |", key,
+                                metadata.partition(),
+                                metadata.offset(),
+                                metadata.timestamp());
+                    }
+                });
+                Thread.sleep(500);
+                producer.flush();
+            } catch (InterruptedException e) {
+                log.error("Thread exception error ", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}
+
+```
+
+### Summary
+
+- **Kafka can handle various data types**: You can send different types of data, but you must provide the correct
+  serializer for that data type.
+
+- **Custom Serializer**: If you want to send List<Producer>, you need to implement a custom serializer that knows how
+  to convert that list into a byte array.
+
+- **JSON String Option**: Alternatively, you can convert the list to a JSON string and use StringSerializer, which is
+  simpler and often sufficient.

--- a/course-kafka-event/src/main/java/code/with/vanilson/KafkaEventStreamApp.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/KafkaEventStreamApp.java
@@ -7,7 +7,7 @@ import code.with.vanilson.event.KafkaEventProducer;
  */
 public class KafkaEventStreamApp {
     public static void main(String[] args) {
-        //Producer sent a message
+        //Product sent a message
         KafkaEventProducer.sendMessge();
     }
 }

--- a/course-kafka-event/src/main/java/code/with/vanilson/config/ProducerConfig.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/config/ProducerConfig.java
@@ -1,5 +1,6 @@
 package code.with.vanilson.config;
 
+import code.with.vanilson.mapper.ListProducerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Properties;
@@ -25,7 +26,7 @@ public class ProducerConfig {
         props.setProperty(ACKS, "all");
         props.setProperty(RETRIES, Integer.toString(Integer.MAX_VALUE));
         props.setProperty(PRODUCER_KEY_SERIALIZER, StringSerializer.class.getName());
-        props.setProperty(PRODUCER_VALUE_SERIALIZER, StringSerializer.class.getName());
+        props.setProperty(PRODUCER_VALUE_SERIALIZER, ListProducerSerializer.class.getName());
         props.setProperty("linger.ms.config", "3");
         props.setProperty("compression.type", "snappy");
         props.setProperty("batch.size", Integer.toString(32 * 1024));

--- a/course-kafka-event/src/main/java/code/with/vanilson/event/KafkaEventProducer.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/event/KafkaEventProducer.java
@@ -1,11 +1,14 @@
 package code.with.vanilson.event;
 
 import code.with.vanilson.config.ProducerConfig;
+import code.with.vanilson.producer.Product;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Properties;
 
 import static code.with.vanilson.util.PropertyUtil.TOPIC;
@@ -27,11 +30,11 @@ public class KafkaEventProducer {
     public static void sendMessge() {
         Properties props = ProducerConfig.getKafkaProperties();
         for (int j = 0; j < 2; j++) {
-            for (int i = 0; i < 100; i++) {
-                String key = "truck_id" + i;
-                String value = "Hello word " + i;
-                try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
-                    ProducerRecord<String, String> record = new ProducerRecord<>(TOPIC, key, value);
+            for (int i = 0; i < 10; i++) {
+                String key = "truck_id " + i;
+                List<Product> value = getProducts();
+                try (KafkaProducer<String, List<Product>> producer = new KafkaProducer<>(props)) {
+                    ProducerRecord<String, List<Product>> record = new ProducerRecord<>(TOPIC, key, value );
                     producer.send(record, (metadata, exception) -> {
                         if (exception != null) {
                             log.error("Error sending record", exception);
@@ -52,6 +55,17 @@ public class KafkaEventProducer {
             }
         }
 
+    }
+
+    private static List<Product> getProducts() {
+        return List.of(
+                new Product("Tv", 12, BigDecimal.valueOf(100_00), "v1"),
+                new Product("Xbox", 2, BigDecimal.valueOf(12000.9999), "v1"),
+                new Product("Mobile", 5, BigDecimal.valueOf(13.000), "v2"),
+                new Product("Books", 5, BigDecimal.valueOf(100), "v2"),
+                new Product("Headphones", 23, BigDecimal.valueOf(45.99), "v3"),
+                new Product("PC", 2, BigDecimal.valueOf(1456.898), "v3")
+        );
     }
 
 }

--- a/course-kafka-event/src/main/java/code/with/vanilson/mapper/ListProducerSerializer.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/mapper/ListProducerSerializer.java
@@ -1,0 +1,44 @@
+package code.with.vanilson.mapper;
+
+import code.with.vanilson.producer.Product;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class ListProducerSerializer implements Serializer<List<Product>> {
+    private static final Logger log = LoggerFactory.getLogger(ListProducerSerializer.class);
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        Serializer.super.configure(configs, isKey);
+    }
+
+    @Override
+    public byte[] serialize(String topic, List<Product> data) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            log.info("Object converted to arrays of bytes success");
+            return mapper.writeValueAsBytes(data);
+
+        } catch (JsonProcessingException e) {
+            log.error("Couldn't serializa object:{}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public byte[] serialize(String topic, Headers headers, List<Product> data) {
+        return Serializer.super.serialize(topic, headers, data);
+    }
+
+    @Override
+    public void close() {
+        Serializer.super.close();
+    }
+}

--- a/course-kafka-event/src/main/java/code/with/vanilson/producer/Product.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/producer/Product.java
@@ -1,0 +1,6 @@
+package code.with.vanilson.producer;
+
+import java.math.BigDecimal;
+
+public record Product(String name, int quantiy, BigDecimal price, String version) {
+}


### PR DESCRIPTION
1. Using a Custom Serializer: If you want to keep using List<Producer>, you need to create a custom serializer that knows how to convert a List<Producer> into a byte array. This serializer would typically convert the list to a JSON string (or another format) and then serialize that string.

 2.Using a Standard Serializer:
        If you convert your List<Producer> to a JSON string, you can use the StringSerializer for the value. This is a common approach because JSON is a widely used format for data interchange.