### PR TITLE
feate: Using Gson for serialization, Kafka producer object

### DIFF
--- a/course-kafka-event/pom.xml
+++ b/course-kafka-event/pom.xml
@@ -51,6 +51,13 @@
             <version>3.9.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/course-kafka-event/src/main/java/code/with/vanilson/event/KafkaEventProducer.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/event/KafkaEventProducer.java
@@ -34,8 +34,8 @@ public class KafkaEventProducer {
                 String key = "truck_id " + i;
                 List<Product> value = getProducts();
                 try (KafkaProducer<String, List<Product>> producer = new KafkaProducer<>(props)) {
-                    ProducerRecord<String, List<Product>> record = new ProducerRecord<>(TOPIC, key, value );
-                    producer.send(record, (metadata, exception) -> {
+                    ProducerRecord<String, List<Product>> listRecord  = new ProducerRecord<>(TOPIC, key, value);
+                    producer.send(listRecord , (metadata, exception) -> {
                         if (exception != null) {
                             log.error("Error sending record", exception);
                         } else {
@@ -64,7 +64,8 @@ public class KafkaEventProducer {
                 new Product("Mobile", 5, BigDecimal.valueOf(13.000), "v2"),
                 new Product("Books", 5, BigDecimal.valueOf(100), "v2"),
                 new Product("Headphones", 23, BigDecimal.valueOf(45.99), "v3"),
-                new Product("PC", 2, BigDecimal.valueOf(1456.898), "v3")
+                new Product("Monitor", 3, BigDecimal.valueOf(1000.898), "v5"),
+                new Product("Gamepad", 11, BigDecimal.valueOf(56.99), "v6")
         );
     }
 

--- a/course-kafka-event/src/main/java/code/with/vanilson/mapper/ListProducerSerializer.java
+++ b/course-kafka-event/src/main/java/code/with/vanilson/mapper/ListProducerSerializer.java
@@ -1,8 +1,7 @@
 package code.with.vanilson.mapper;
 
 import code.with.vanilson.producer.Product;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
@@ -19,17 +18,33 @@ public class ListProducerSerializer implements Serializer<List<Product>> {
         Serializer.super.configure(configs, isKey);
     }
 
+//    @Override
+//    public byte[] serialize(String topic, List<Product> data) {
+//        ObjectMapper mapper = new ObjectMapper();
+//        try {
+//            log.info("Object converted to arrays of bytes success");
+//            return mapper.writeValueAsBytes(data);
+//
+//        } catch (JsonProcessingException e) {
+//            log.error("Couldn't serializa object:{}", e.getMessage());
+//            throw new RuntimeException(e);
+//        }
+//    }
+
+    /**
+     * Converts product to bytes using gson.
+     *
+     * @param topic topic associated with data
+     * @param data  typed data
+     * @return data converted in bytes
+     */
     @Override
     public byte[] serialize(String topic, List<Product> data) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            log.info("Object converted to arrays of bytes success");
-            return mapper.writeValueAsBytes(data);
+        Gson gson = new Gson();
+        log.info("Object converted to arrays of bytes success");
+        //Convert to JSON and then to byte array
+        return gson.toJson(data).getBytes();
 
-        } catch (JsonProcessingException e) {
-            log.error("Couldn't serializa object:{}", e.getMessage());
-            throw new RuntimeException(e);
-        }
     }
 
     @Override


### PR DESCRIPTION
Yes, using Gson for converting objects to byte arrays (and vice versa) is a great option! Gson is a popular library for JSON serialization and deserialization in Java, and it can be simpler and more lightweight compared to Jackson in some cases.

### Advantages of Using Gson

1. **Simplicity**: Gson has a straightforward API that is easy to use for converting Java objects to JSON and back.
2. **Lightweight**: Gson is generally smaller in size compared to Jackson, which can be beneficial if you're looking to minimize dependencies.
3. **Flexibility**: Gson can handle a wide variety of Java types, including collections and nested objects.

### Example of Using Gson for Serialization and Deserialization

Here’s how you can modify the custom serializers and deserializers to use Gson instead of Jackson:

#### Custom Serializer Using Gson

```java
import com.google.gson.Gson;
import org.apache.kafka.common.serialization.Serializer;

import java.util.Map;

public class ProductSerializer implements Serializer<Product> {
    private final Gson gson = new Gson();

    @Override
    public byte[] serialize(String topic, Product data) {
        return gson.toJson(data).getBytes(); // Convert to JSON and then to byte array
    }

    @Override
    public void configure(Map<String, ?> configs, boolean isKey) {}

    @Override
    public void close() {}
}
```

#### Custom Deserializer Using Gson

```java
import com.google.gson.Gson;
import org.apache.kafka.common.serialization.Deserializer;

import java.util.Map;

public class ProductDeserializer implements Deserializer<Product> {
    private final Gson gson = new Gson();

    @Override
    public Product deserialize(String topic, byte[] data) {
        return gson.fromJson(new String(data), Product.class); // Convert byte array to JSON string and then to object
    }

    @Override
    public void configure(Map<String, ?> configs, boolean isKey) {}

    @Override
    public void close() {}
}
```

### Summary

Using Gson for serialization and deserialization in your Kafka producer and consumer is a valid and often effective choice. It can simplify your code and reduce the number of dependencies. Just make sure to include the Gson library in your project dependencies.

If you decide to switch to Gson, you can replace the Jackson-based serializers and deserializers in your Kafka setup with the Gson-based ones as shown above. If you have any further questions or need assistance with this, feel free to ask!